### PR TITLE
Ignore stack build results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.stack-work


### PR DESCRIPTION
This PR make git ignores stack build results with `.gitignore`. Someone can accidentally check in those build results.
