### PR TITLE
Remove resolver overriding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ cache:
 matrix:
   include:
 
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=stack
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=stack
     compiler: ": #stack nightly osx"
     os: osx
 
@@ -42,9 +42,9 @@ before_install:
 
 install:
 - if [ -f configure.ac ]; then autoreconf -i; fi
-- stack --no-terminal --install-ghc $ARGS test --only-dependencies
+- stack --no-terminal --install-ghc test --only-dependencies
 
 script:
 - |
-  stack --no-terminal $ARGS test --haddock --no-haddock-deps
+  stack --no-terminal test --haddock --no-haddock-deps
   stack --no-terminal install


### PR DESCRIPTION
For now, travis build fails due to with the message like:

``` travis
While constructing the build plan, the following exceptions were encountered:
In the dependencies for chips-1.0.0:
    aeson-1.0.1.0 must match >=0.11.1.4 && <0.12 (latest applicable is 0.11.2.1)
Plan construction failed.
The command "stack --no-terminal --install-ghc $ARGS test --only-dependencies" failed and exited with 1 during .
```

This is due to resolver(snapshot?) overriding caused by `--resolver nightly` option in `.travis.yml`. So I just deleted that part and now build works just fine. Still, I'm not sure whether this deletion might cause undesired side effects or not so please check if there's any.
