### PR TITLE
Support fish 2.0.0

### DIFF
--- a/integration/build.fish
+++ b/integration/build.fish
@@ -1,2 +1,2 @@
 alias chips "/home/user/integration/chips; exec fish"
-source /home/user/.config/chips/dist/fish-sensible/init.fish
+. /home/user/.config/chips/dist/fish-sensible/init.fish

--- a/integration/config.fish
+++ b/integration/config.fish
@@ -1,2 +1,2 @@
 # chips
-if [ -e ~/.config/chips/build.fish ] ; source ~/.config/chips/build.fish ; end
+if [ -e ~/.config/chips/build.fish ] ; . ~/.config/chips/build.fish ; end

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -139,7 +139,7 @@ runSync Session{..} = do
     fishPromptPath = functionsDir </> "fish_prompt.fish"
     fishRightPath = functionsDir </> "fish_right_prompt.fish"
     sourceInit initPath = mconcat
-        [ "source "
+        [ ". "
         , B.byteString $ pluginsDir </> initPath
         , "\n"
         ]


### PR DESCRIPTION
Even though the usage of the `.` is deprecated in favour of `source`,
there is no other way to support fish 2.0.0 without it.
###### References:
- https://github.com/fish-shell/fish-shell/issues/310
- https://github.com/fish-shell/fish-shell/commit/edc4614e6339f8e232d1c86d2fe4f15c91ced5b8
- http://fish.sh/docs/current/commands.html#source-description
