### PR TITLE
Support fish 2.0.0 in config.fish

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -230,4 +230,4 @@ chipsLineInConfig = "# chips" <> sourceLine
 sourceLine :: ByteString
 sourceLine = "\n\
 \if [ -e ~/.config/chips/build.fish ] ;\
-\ source ~/.config/chips/build.fish ; end\n"
+\ . ~/.config/chips/build.fish ; end\n"


### PR DESCRIPTION
Even though the usage of the [`.`][`source`] is deprecated in favour of [`source`], there is no other way to support fish 2.0.0 without it.

There's no other way to workaround this problem except doing like this:

```fish
# The "real" fish config who loads chips
if [ -e ~/.config/chips/build.fish ] ; . ~/.config/chips/build.fish ; end

# Dummy fish config to deceive chips
set __dummy__ "
if [ -e ~/.config/chips/build.fish ] ; source ~/.config/chips/build.fish ; end
"
```

This commit is follow-up of #25. I've missed some code that uses the [`source`] command.

###### References
- https://github.com/xtendo-org/chips/pull/25
- https://github.com/simnalamburt/.dotfiles/blob/c404d6cc/config.fish#L62-L67
- https://github.com/fish-shell/fish-shell/issues/310
- https://github.com/fish-shell/fish-shell/commit/edc4614e6339f8e232d1c86d2fe4f15c91ced5b8
- http://fish.sh/docs/current/commands.html#source-description

[`source`]: http://fish.sh/docs/current/commands.html#source