### PR TITLE
chips 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.1.2 - 2017-01-16
+
+### Fixed
+
+- [#28], Follow-up to support the version of fish included in Ubuntu 14.04 LTS in config.fish.
+
 ## 1.1.1 - 2016-11-09
 
 ### Fixed
@@ -27,3 +33,5 @@
 ## 1.0.0 - 2016-04-01
 
 - Initial release.
+
+[#28]: https://github.com/xtendo-org/chips/pull/28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 ### Fixed
 
-- The chips executable after self-update will now have the `+x` permission.
-- Executing chips with command line arguments will not cause shell exit anymore.
-- Now works with the version of fish included in Ubuntu 14.04 LTS.
+- [#23], The chips executable after self-update will now have the `+x` permission.
+- [#26], Executing chips with command line arguments will not cause shell exit anymore.
+- [#25], Now works with the version of fish included in Ubuntu 14.04 LTS.
 
 ## 1.1.0 - 2016-10-02
 
@@ -26,8 +26,8 @@
 ### Fixed
 
 - Failure when `$HOME` and `/tmp` were not in the same disk.
-- Failure when config.fish is missing
-- Hang due to GitHub request burst (added request intervals)
+- [#18], Failure when config.fish is missing
+- [`358fe7c3`], Hang due to GitHub request burst (added request intervals)
 - Misbehavior when chips is run offline
 
 ## 1.0.0 - 2016-04-01
@@ -35,3 +35,8 @@
 - Initial release.
 
 [#28]: https://github.com/xtendo-org/chips/pull/28
+[#26]: https://github.com/xtendo-org/chips/issues/26
+[#25]: https://github.com/xtendo-org/chips/pull/25
+[#23]: https://github.com/xtendo-org/chips/issues/23
+[#18]: https://github.com/xtendo-org/chips/pull/18
+[`358fe7c3`]: https://github.com/xtendo-org/chips/commit/358fe7c3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A plugin manager for [fish].
 
 ## Installation
 
-Current version: **chips 1.1.1** (2017-01-16)
+Current version: **chips 1.1.2** (2017-01-16)
 
 ### GNU/Linux (x64)
 
@@ -20,7 +20,7 @@ Assuming `~/.local/bin` is in your `$PATH`:
 
 ```fish
 curl -Lo ~/.local/bin/chips --create-dirs \
-    https://github.com/xtendo-org/chips/releases/download/1.1.1/chips_gnulinux \
+    https://github.com/xtendo-org/chips/releases/download/1.1.2/chips_gnulinux \
     ; and chmod +x ~/.local/bin/chips
 ```
 
@@ -30,7 +30,7 @@ Assuming `~/.local/bin` is in your `$PATH`:
 
 ```fish
 curl -Lo ~/.local/bin/chips --create-dirs \
-    https://github.com/xtendo-org/chips/releases/download/1.1.1/chips_osx \
+    https://github.com/xtendo-org/chips/releases/download/1.1.2/chips_osx \
     ; and chmod +x ~/.local/bin/chips
 ```
 

--- a/chips.cabal
+++ b/chips.cabal
@@ -1,5 +1,5 @@
 name:               chips
-version:            1.1.1
+version:            1.1.2
 synopsis:           A plugin manager for the fish shell
 description:        Please see README.md
 homepage:           https://github.com/xtendo-org/chips#readme

--- a/integration/chips_initial_run.txt
+++ b/integration/chips_initial_run.txt
@@ -1,5 +1,5 @@
 chips: fish plugin manager
-version 1.1.1
+version 1.1.2
 chips has just created the default configuration at:
     /home/user/.config/chips/plugin.yaml
 Please edit the file and run chips again.

--- a/integration/install.txt
+++ b/integration/install.txt
@@ -1,2 +1,2 @@
 chips: fish plugin manager
-version 1.1.1
+version 1.1.2


### PR DESCRIPTION
This release just contains https://github.com/xtendo-org/chips/pull/28, but it's important for legacy system users.

#### Attachment: [chips_osx.zip](https://github.com/xtendo-org/chips/files/708199/chips_osx.zip) (3.93 MB)
Built with the command below in macOS Sierra
```fish
# Release steps for macOS
stack build; \
    and cp .stack-work/install/x86_64-osx/nightly-2016-10-29/8.0.1/bin/chips chips_osx; \
    and strip -u -r chips_osx; \
    and upx -9 --lzma chips_osx; \
    and zip chips_osx.zip chips_osx; \
    and rm chips_osx
```


